### PR TITLE
Fix wrong description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ workflow "Triage" {
 
 action "Assign MonaLisa" {
   uses = "actions/github@v1.0.0"
-  args = "assign @monalisaoctocat --action=opened" # Only when issues are opened!
+  args = "assign monalisaoctocat --action=opened" # Only when issues are opened!
   secrets = ["GITHUB_TOKEN"]
 }
 ```


### PR DESCRIPTION
There was wrong description in README

When assign a issue to someone, use `assign <username>`, not `assign @<username>`

So I fixed it :+1:  
Plz check this pr